### PR TITLE
Fallback to direct Ollama chat when agent endpoints are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project appears to be a server and client implementation for the Model Cont
 *   **Local MCP Modules:** Python modules (`mcp_local_modules/`) for handling MCP setup, configuration, and utility functions.
 *   **Documentation:** Contains project-related documentation in the `docs/` directory.
 *   **Sample MCP Files:** Includes example files related to MCP in `sample_mcp_files/`.
+*   **Ollama Agent Support:** Local Ollama models are routed through the OpenAI Agents SDK when possible. If the Ollama server lacks certain agent endpoints, the CLI falls back to a direct chat path.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- add back a direct-chat helper for Ollama models
- detect `openai.NotFoundError` in the CLI and fall back to direct Ollama chat
- update README to mention the fallback

## Testing
- `python -m py_compile agentcli.py cli/cli_model_handler.py minimal_ollama_test.py ollama_chat.py`